### PR TITLE
Support non-rpm systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A playbook for installing and running a Gitlab Runner instance using Podman
 using a normal user. The container still needs to run privileged.
 
-Supports Fedora 33.
+Supports Fedora 33, Debian 12.
 
 ## Installation
 

--- a/roles/gitlab_runner/tasks/podman.yml
+++ b/roles/gitlab_runner/tasks/podman.yml
@@ -1,10 +1,18 @@
 ---
-- name: "Install Podman and dependencies"
+- name: "Install Podman and dependencies (RedHat family)"
+  when: ansible_facts['os_family'] == "RedHat"
   become: yes
   dnf:
     name:
       - podman
       - python3-libselinux
+
+- name: "Install Podman and dependencies (non-RedHat family)"
+  when: ansible_facts['os_family'] != "RedHat"
+  become: yes
+  ansible.builtin.package:
+    name:
+      - podman
 
 - name: "Add explicit cgroupfs configuration"
   become: yes


### PR DESCRIPTION
DNF is only available on Fedora. Switch to the more general package for other OSes.

I've tested this with Debian 12 and adjusted your role for this.